### PR TITLE
Add support for new runtimes

### DIFF
--- a/aws-apprunner-service/aws-apprunner-service.json
+++ b/aws-apprunner-service/aws-apprunner-service.json
@@ -96,7 +96,10 @@
                     "description": "Runtime",
                     "enum": [
                         "PYTHON_3",
-                        "NODEJS_12"
+                        "NODEJS_12",
+                        "NODEJS_14",
+                        "CORRETTO_8",
+                        "CORRETTO_11"
                     ]
                 },
                 "BuildCommand": {

--- a/aws-apprunner-service/docs/codeconfigurationvalues.md
+++ b/aws-apprunner-service/docs/codeconfigurationvalues.md
@@ -39,7 +39,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code>
+_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code> | <code>NODEJS_14</code> | <code>CORRETTO_8</code> | <code>CORRETTO_11</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
_Description of changes:_
Add new runtime support for Corretto8, Corretto11 and Nodejs14.

_Testing:_
`mvn package` succeeds locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
