### PR TITLE
New runtimes support

### DIFF
--- a/aws-apprunner-service/aws-apprunner-service.json
+++ b/aws-apprunner-service/aws-apprunner-service.json
@@ -99,7 +99,12 @@
                         "NODEJS_12",
                         "NODEJS_14",
                         "CORRETTO_8",
-                        "CORRETTO_11"
+                        "CORRETTO_11",
+                        "NODEJS_16",
+                        "GO_1",
+                        "DOTNET_6",
+                        "PHP_81",
+                        "RUBY_31"
                     ]
                 },
                 "BuildCommand": {

--- a/aws-apprunner-service/docs/codeconfigurationvalues.md
+++ b/aws-apprunner-service/docs/codeconfigurationvalues.md
@@ -39,7 +39,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code> | <code>NODEJS_14</code> | <code>CORRETTO_8</code> | <code>CORRETTO_11</code>
+_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code> | <code>NODEJS_14</code> | <code>NODEJS_16</code> | <code>CORRETTO_8</code> | <code>CORRETTO_11</code> | <code>GO_1</code> | <code>DOTNET_6</code> | <code>PHP_81</code> | <code>RUBY_31</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:* Add new runtime support for Node.js16, DotNet6, Go1, PHP8.1 and Ruby3.1.


*Description of changes:* Add new runtime support for Node.js16, DotNet6, Go1, PHP8.1 and Ruby3.1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
