### PR TITLE
Add support for Nodejs18 and Python3.11

### DIFF
--- a/aws-apprunner-service/aws-apprunner-service.json
+++ b/aws-apprunner-service/aws-apprunner-service.json
@@ -104,7 +104,9 @@
                         "GO_1",
                         "DOTNET_6",
                         "PHP_81",
-                        "RUBY_31"
+                        "RUBY_31",
+                        "PYTHON_311",
+                        "NODEJS_18"
                     ]
                 },
                 "BuildCommand": {

--- a/aws-apprunner-service/docs/codeconfigurationvalues.md
+++ b/aws-apprunner-service/docs/codeconfigurationvalues.md
@@ -39,7 +39,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code> | <code>NODEJS_14</code> | <code>NODEJS_16</code> | <code>CORRETTO_8</code> | <code>CORRETTO_11</code> | <code>GO_1</code> | <code>DOTNET_6</code> | <code>PHP_81</code> | <code>RUBY_31</code>
+_Allowed Values_: <code>PYTHON_3</code> | <code>NODEJS_12</code> | <code>NODEJS_14</code> | <code>NODEJS_16</code> | <code>CORRETTO_8</code> | <code>CORRETTO_11</code> | <code>GO_1</code> | <code>DOTNET_6</code> | <code>PHP_81</code> | <code>RUBY_31</code> | <code>PYTHON_311</code> | <code>NODEJS_18</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 


### PR DESCRIPTION
*Issue #, if available:* Add new runtime support for Node.js18, Python3.11.

*Description of changes:* Add new runtime support for Node.js18, Python3.11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
